### PR TITLE
Turn on retries for rsync bulk move task

### DIFF
--- a/laxy_backend/admin.py
+++ b/laxy_backend/admin.py
@@ -230,9 +230,9 @@ class JobAdmin(Timestamped, VersionAdmin):
     list_display = (
         "uuid",
         "created",
-        "modified",
         "completed",
         "expires",
+        "_pipeline",
         "_compute_resource",
         "_owner_email",
         "_status",
@@ -271,6 +271,13 @@ class JobAdmin(Timestamped, VersionAdmin):
 
     def expires(self, obj: Job):
         return humanize.naturaltime(obj.expiry_time)
+
+    def _pipeline(self, obj: Job):
+        pipeline = obj.params.get("pipeline", None)
+        pipeline_version = obj.params.get("params", {}).get("pipeline_version", None)
+        if pipeline is not None:
+            return format_html(f"{pipeline} ({pipeline_version})")
+        return format_html("<i>???</i>")
 
     def _compute_resource(self, obj: Job):
         c = obj.compute_resource

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ celery==4.4.7
 certifi==2018.1.18
 cffi==1.11.5
 chardet==3.0.4
-codecov==2.1.13
+#codecov==2.1.13
 coreapi==2.3.3
 coreschema==0.0.4
 coverage==4.4.2


### PR DESCRIPTION
This updates the task for bulk file transfer via rsync to do retries with backoff. Previously settings were commented and appropriate `self.retry()` was (intentionally) missing.